### PR TITLE
add `files` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@paralleldrive/cuid2",
   "private": false,
   "types": "index.d.ts",
+  "files": [
+    "src/index.js",
+    "index.js",
+    "index.d.ts"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Added `files` to the `package.json` file in order to reduce the files included when installing the `@paralleldrive/cuid2` package

### Before
![image](https://user-images.githubusercontent.com/42935195/215852874-7f218e64-b057-40ad-a9b0-4a0af6905d68.png)

### After
![image](https://user-images.githubusercontent.com/42935195/215852900-44fd1896-50cc-4464-a291-5f0ffab701a3.png)
