### PR TITLE
fix: create entropy should use supplied random

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,11 +53,12 @@ const createFingerprint = ({
     : typeof window !== "undefined"
     ? window
     : {},
+  random = Math.random,
 } = {}) => {
   const globals = Object.keys(globalObj).toString();
   const sourceString = globals.length
-    ? globals + createEntropy(bigLength)
-    : createEntropy(bigLength);
+    ? globals + createEntropy(bigLength, random)
+    : createEntropy(bigLength, random);
 
   return hash(sourceString).substring(0, bigLength);
 };
@@ -77,7 +78,7 @@ const init = ({
   random = Math.random,
   counter = createCounter(Math.floor(random() * initialCountMax)),
   length = defaultLength,
-  fingerprint = createFingerprint(),
+  fingerprint = createFingerprint({ random }),
 } = {}) => {
   return function cuid2() {
     const firstLetter = randomLetter(random);


### PR DESCRIPTION
We weren't passing the custom random function to `createEntropy`. Fixed in this commit.

@nlepage Please review