### PR TITLE
feat: add textencoder polyfill for react native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^1.1.5"
+        "@noble/hashes": "^1.1.5",
+        "text-encoding-polyfill": "^0.6.7"
       },
       "devDependencies": {
         "eslint": "8.30.0",
@@ -7024,6 +7025,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/text-encoding-polyfill": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
+      "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13111,6 +13117,11 @@
           }
         }
       }
+    },
+    "text-encoding-polyfill": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
+      "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "watch": "1.0.2"
   },
   "dependencies": {
-    "@noble/hashes": "^1.1.5"
+    "@noble/hashes": "^1.1.5",
+    "text-encoding-polyfill": "^0.6.7"
   },
   "version": "2.2.0"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /* global global, window, module */
+require("text-encoding-polyfill");
 const { sha3_512: sha3 } = require("@noble/hashes/sha3");
 
 const defaultLength = 24;


### PR DESCRIPTION
Closes #28 and #31

Added a polyfill for `TextEncoder` which doesn't seem to exist in the hermes JS engine used by expo/react-native