### PR TITLE
README.md: improve `init` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,15 @@ const ids = [
 import { init } from '@paralleldrive/cuid2';
 
 // The init function returns a custom createId function with the specified
-// configuration.
+// configuration. All configuration properties are optional.
 const createId = init({
   // A custom random function with the same API as Math.random.
-  // You should use this to pass a cryptographically secure random function.
+  // You can use this to pass a cryptographically secure random function.
   random: Math.random,
-  length: 10, // the length of the id
+  // the length of the id
+  length: 10,
+  // A custom fingerprint for the host environment. This is used to help
+  // prevent collisions when generating ids in a distributed system.
   fingerprint: 'a-custom-host-fingerprint',
 });
 


### PR DESCRIPTION
Explain that:
- all configuration properties are optional
- you can pass a `random` function (but you don’t have to)
- `fingerprint` is a custom fingerprint string for the host environment

For context, I wanted to use `init` to set only the `length` of the id, but was not sure what to do about the other properties, and I didn’t understand what `fingerprint` was for. I felt the README could be more descriptive.