### PR TITLE
docs: add go port to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Most stronger forms of the UUID / GUID algorithms require access to OS services 
 * [Cuid2 for Python](https://github.com/gordon-code/cuid2) - [Gordon Code](https://github.com/gordon-code)
 * [Cuid2 for Ruby](https://github.com/stulzer/cuid2/blob/main/lib/cuid2.rb) - [Rubens Stulzer](https://github.com/stulzer)
 * [Cuid2 for Rust](https://github.com/mplanchard/cuid-rust) - [Matthew Planchard](https://github.com/mplanchard)
+* [Cuid2 for Go](https://github.com/nrednav/cuid2) - [Vandern Rodrigues](https://github.com/nrednav)
 
 ## Improvements Over Cuid
 


### PR DESCRIPTION
Link to port: [nrednav/cuid2](https://github.com/nrednav/cuid2)

Apologies for yet another Go port of this library. I noticed the other implementations did not include a complete suite of tests and so I wanted to try my hand at recreating the full package, including collision tests.

I tried to incorporate as much as I could gather from the ongoing discussion in https://github.com/paralleldrive/cuid2/issues/33. Would greatly appreciate any feedback.

## Todo / Missing
- [ ] Add histogram.go with tests for `buildHistogram`