### PR TITLE
fix: sha3 512 hashing causing issues switched to pure javascript hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^1.1.5"
+        "js-sha3": "^0.9.1"
       },
       "devDependencies": {
         "eslint": "8.30.0",
@@ -443,17 +443,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
-      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4473,6 +4462,11 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.1.tgz",
+      "integrity": "sha512-BEtdfjzc2zf276Ck8FprMl0ej0rFrK3TSwNSzFjDvv/QOj2YlWmoRBOIZaaUHFWJAXHl2KfiwVBIbYYeHHtCNA=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8338,11 +8332,6 @@
       "dev": true,
       "optional": true
     },
-    "@noble/hashes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
-      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11273,6 +11262,11 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
       "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
       "dev": true
+    },
+    "js-sha3": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.1.tgz",
+      "integrity": "sha512-BEtdfjzc2zf276Ck8FprMl0ej0rFrK3TSwNSzFjDvv/QOj2YlWmoRBOIZaaUHFWJAXHl2KfiwVBIbYYeHHtCNA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "watch": "1.0.2"
   },
   "dependencies": {
-    "@noble/hashes": "^1.1.5"
+    "js-sha3": "^0.9.1"
   },
   "version": "2.2.2"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /* global global, window, module */
-const { sha3_512: sha3 } = require("@noble/hashes/sha3");
+const { sha3_512: sha3} = require('js-sha3');
 
 const defaultLength = 24;
 const bigLength = 32;
@@ -31,7 +31,7 @@ function bufToBigInt(buf) {
 const hash = (input = "") => {
   // Drop the first character because it will bias the histogram
   // to the left.
-  return bufToBigInt(sha3(input)).toString(36).slice(1);
+  return bufToBigInt(sha3.array(input)).toString(36).slice(1);
 };
 
 const alphabet = Array.from({ length: 26 }, (x, i) =>


### PR DESCRIPTION
This should close #56

I switched cuid2 to js-sha3, a pure javascript implementation that should work better on slim environments like Vercel. 

It passes all tests.