### PR TITLE
CUID port for go doc added

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Most stronger forms of the UUID / GUID algorithms require access to OS services 
 * [Cuid2 for Python](https://github.com/gordon-code/cuid2) - [Gordon Code](https://github.com/gordon-code)
 * [Cuid2 for Ruby](https://github.com/stulzer/cuid2/blob/main/lib/cuid2.rb) - [Rubens Stulzer](https://github.com/stulzer)
 * [Cuid2 for Rust](https://github.com/mplanchard/cuid-rust) - [Matthew Planchard](https://github.com/mplanchard)
+* [Cuid2 for Go](https://github.com/akshayvadher/cuid2) - [Akshay Vadher](https://github.com/akshayvadher)
 
 ## Improvements Over Cuid
 


### PR DESCRIPTION
Since the readme didn't have a Go port, I only discovered two ports had already been created for Go when I came to PR. My bad. 

Anyway, I created one at https://github.com/akshayvadher/cuid2

I have added all the histograms, char frequencies, and collision tests.

I made the syntax and structure as similar as possible so that reviewers could review it easily and make future changes easier.  
Instead of removing the first char from the hash, I returned it as it was; the collision and histogram tests were failing (to test out that IDs are correctly generated and tests are correctly testing). 

The entropy generator uses global variables (ENV variable keys).

Changes: 
- Instead of `^[0-9a-z]+$`, the test CUID function checks for `^[a-z][0-9a-z]+$` for more accurate result
- For histogram test, instead of dropping the first two chars (`.slice(2)`), I am dropping only the first for more accurate testing