### PR TITLE
Fix isCuid validation for non-CUID strings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace cuid2 {
     fingerprint?: string
   }): () => string
 
-  export function isCuid(id: string): boolean
+  export function isCuid(id: string, options?: { minLength?: number, maxLength?: number }): boolean
 
   export function createId(): string
 }

--- a/src/index-test.js
+++ b/src/index-test.js
@@ -189,11 +189,11 @@ describe("isCuid", async (assert) => {
 
   {
     const actual = isCuid("aaaaDLL");
-    const expected = true;
+    const expected = false;
 
     assert({
-      given: "a valid CUID2 string",
-      should: "return true",
+      given: "a string with capital letters",
+      should: "return false",
       actual,
       expected,
     });

--- a/src/index-test.js
+++ b/src/index-test.js
@@ -174,4 +174,64 @@ describe("isCuid", async (assert) => {
       expected,
     });
   }
+
+  {
+    const actual = isCuid("42");
+    const expected = false;
+
+    assert({
+      given: "a non-CUID string",
+      should: "return false",
+      actual,
+      expected,
+    });
+  }
+
+  {
+    const actual = isCuid("aaaaDLL");
+    const expected = true;
+
+    assert({
+      given: "a valid CUID2 string",
+      should: "return true",
+      actual,
+      expected,
+    });
+  }
+
+  {
+    const actual = isCuid("yi7rqj1trke");
+    const expected = true;
+
+    assert({
+      given: "a valid CUID2 string",
+      should: "return true",
+      actual,
+      expected,
+    });
+  }
+
+  {
+    const actual = isCuid("-x!ha");
+    const expected = false;
+
+    assert({
+      given: "a string with invalid characters",
+      should: "return false",
+      actual,
+      expected,
+    });
+  }
+
+  {
+    const actual = isCuid("ab*%@#x");
+    const expected = false;
+
+    assert({
+      given: "a string with invalid characters",
+      should: "return false",
+      actual,
+      expected,
+    });
+  }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ const createId = init();
 
 const isCuid = (id, { minLength = 2, maxLength = bigLength } = {}) => {
   const length = id.length;
-  const regex = /^[0-9a-z]+$/;
+  const regex = /^[a-z][0-9a-z]+$/;
 
   try {
     if (


### PR DESCRIPTION
Fixes #79

Update `isCuid` function to correctly validate CUID strings and add type definitions for options parameter.

* **Tests**: Add test cases in `src/index-test.js` to cover new validation criteria for `isCuid` function. Ensure tests check for valid CUIDs starting with a letter, within length range, and using only valid CUID2 characters.
* **Type Definitions**: Add `options` parameter to `isCuid` function definition in `index.d.ts`. Include `minLength` and `maxLength` properties in `options`.
* **Function Update**: Update `isCuid` function in `src/index.js` to include validation criteria: starts with a letter, has size within range, uses only valid CUID2 characters. 

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paralleldrive/cuid2/issues/79?shareId=dda13cf6-54a2-4415-bc33-abe035868122).