### PR TITLE
Replace trailing n BigInt notation in bufToBigInt function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,9 +18,9 @@ const createEntropy = (length = 4, random = Math.random) => {
  * MIT License Copyright (c) 2018 Juan Hernández Serrano
  */
 function bufToBigInt(buf) {
-  let bits = 8n;
+  let bits = BigInt(8);
 
-  let value = 0n;
+  let value = BigInt(0);
   for (const i of buf.values()) {
     const bi = BigInt(i);
     value = (value << bits) + bi;


### PR DESCRIPTION
the trailing n notation doesn't get transpiled and throws an `Unexpected token ILLEGAL` error in older browsers, like Chrome 38, used in some LG TV models. 
using the BigInt() function call instead, the error is not thrown.
![image](https://github.com/user-attachments/assets/900ea00d-8ce2-4c9c-a4c7-2e359744f256)

