### PR TITLE
Update @noble/hashes to version 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^1.1.5"
+        "@noble/hashes": "^1.7.1"
       },
       "devDependencies": {
         "eslint": "8.30.0",
@@ -445,15 +445,16 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
-      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8339,9 +8340,9 @@
       "optional": true
     },
     "@noble/hashes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
-      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "watch": "1.0.2"
   },
   "dependencies": {
-    "@noble/hashes": "^1.1.5"
+    "@noble/hashes": "^1.7.1"
   },
   "version": "2.2.2"
 }


### PR DESCRIPTION
This PR updates the @noble/hashes to version 1.7.1. The main motivation for me is to get the big endian support that was added in @noble/hashes version 1.4.0 so that cuid2 can work on the s390x architecture. With this change, all tests pass on s390x and amd64 in my testing.
