### PR TITLE
Breaking release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ First, install the shell alias for easier access:
 
 ```bash
 # Install shell alias (recommended)
-npx @paralleldrive/cuid2 --install-alias
+npx @paralleldrive/cuid2 --install
 # ✓ Alias added to .zshrc
 # Run: source ~/.zshrc
+
+# View all CLI options
+npx @paralleldrive/cuid2 --help
 ```
 
 Now generate IDs from the command line:
@@ -80,6 +83,22 @@ cuid --length 8 --fingerprint "test"
 
 # Without alias, use the full command
 npx @paralleldrive/cuid2
+```
+
+#### CLI Options
+
+```bash
+cuid2 [count] [options]
+
+Arguments:
+  count              Number of IDs to generate (default: 1)
+
+Options:
+  --slug             Generate a short 5-character ID
+  --length <n>       Custom ID length (default: 24)
+  --fingerprint <s>  Custom fingerprint for ID generation
+  --install          Install shell alias 'cuid' → 'npx @paralleldrive/cuid2'
+  --help, -h         Show help message
 ```
 
 ### Programmatic Usage

--- a/bin/cuid2.js
+++ b/bin/cuid2.js
@@ -7,6 +7,34 @@ import { join } from "path";
 
 const args = process.argv.slice(2);
 
+// Handle --help
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`
+cuid2 - Secure, collision-resistant ID generator
+
+Usage: cuid2 [count] [options]
+
+Arguments:
+  count              Number of IDs to generate (default: 1)
+
+Options:
+  --slug             Generate a short 5-character ID
+  --length <n>       Custom ID length (default: 24)
+  --fingerprint <s>  Custom fingerprint for ID generation
+  --install          Install shell alias 'cuid' → 'npx @paralleldrive/cuid2'
+  --help, -h         Show this help message
+
+Examples:
+  cuid2                           # Generate one ID
+  cuid2 5                         # Generate 5 IDs
+  cuid2 --slug                    # Generate a short ID (5 chars)
+  cuid2 --length 10               # Generate 10-character ID
+  cuid2 --fingerprint "server1"   # Generate ID with custom fingerprint
+  cuid2 --install                 # Install shell alias
+  `);
+  process.exit(0);
+}
+
 // Handle --install-alias
 if (args.includes("--install")) {
   const shellConfigFiles = [".zshrc", ".bashrc", ".bash_profile", ".profile"];

--- a/src/bin-test.js
+++ b/src/bin-test.js
@@ -114,4 +114,30 @@ describe("CLI bin/cuid2.js", async (assert) => {
       expected: true,
     });
   }
+
+  {
+    const output = runCli("--help");
+    const hasUsage = output.includes("Usage:");
+    const hasOptions = output.includes("Options:");
+    const hasExamples = output.includes("Examples:");
+
+    assert({
+      given: "the help flag",
+      should: "display usage information with options and examples",
+      actual: hasUsage && hasOptions && hasExamples,
+      expected: true,
+    });
+  }
+
+  {
+    const output = runCli("-h");
+    const hasUsage = output.includes("Usage:");
+
+    assert({
+      given: "the short help flag",
+      should: "display usage information",
+      actual: hasUsage,
+      expected: true,
+    });
+  }
 });


### PR DESCRIPTION
✅ CLI help flags (--help and -h) with comprehensive usage information
✅ Refined --install flag naming
✅ Updated README documentation with CLI options section
✅ New test cases for help functionality
✅ All tests passing (including 11.5M+ collision tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CLI help (-h/--help), renames install flag to --install, updates README with CLI options, and adds tests for help output.
> 
> - **CLI**:
>   - Add `--help`/`-h` to display usage, options, and examples in `bin/cuid2.js`.
>   - Rename `--install-alias` to `--install` for alias setup.
> - **Docs**:
>   - Update `README.md` to use `--install`, add CLI options/help section, and usage examples.
> - **Tests**:
>   - Extend `src/bin-test.js` with cases validating `--help` and `-h` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e741f50e782ef65e0bb212ec2c032dd5cebb31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->