### PR TITLE
chore: added export module export field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
     "index.d.ts",
     "bin/cuid2.js"
   ],
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "types": "./index.d.ts"
+    }
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
I got a Deprecation warning when running my program. 

This PR addresses the warning. I testing locally and also published my fork and I stopped getting this error.  

<img width="1081" height="427" alt="image" src="https://github.com/user-attachments/assets/e8891144-28e7-4db9-ad58-9a5e82942ab7" />
