### PR TITLE
fix: add exports field to resolve Node.js DEP0151 deprecation warning

### DIFF
--- a/activity-log.md
+++ b/activity-log.md
@@ -1,5 +1,9 @@
 # Activity Log
 
+## 2025-10-26
+
+- 🐛 - add exports field to package.json to resolve Node.js DEP0151 deprecation warning
+
 ## 2025-10-07
 
 - 🚀 - modernize release script with custom Node.js implementation including error handling, branch validation, and bump type aliases

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "private": false,
   "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "cuid2": "./bin/cuid2.js"
   },


### PR DESCRIPTION
## Problem
The package currently triggers deprecation warnings in Node.js 20+ due to missing `exports` field in package.json:

```
[DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json
```

## Solution
Added proper `exports` field to package.json that:
- ✅ Defines the main ESM entry point (`./index.js`)
- ✅ Includes TypeScript types (`./index.d.ts`)
- ✅ Allows importing `package.json`
- ✅ Maintains full backward compatibility

## Changes
```json
"exports": {
  ".": {
    "types": "./index.d.ts",
    "import": "./index.js",
    "default": "./index.js"
  },
  "./package.json": "./package.json"
}
```

## Testing
- ✅ Ran `npm test` - all 33 tests pass
- ✅ Verified imports work correctly
- ✅ No breaking changes to existing functionality

## References
- [Node.js Package Entry Points](https://nodejs.org/api/packages.html#package-entry-points)
- [Node.js DEP0151 Deprecation](https://nodejs.org/api/deprecations.html#dep0151-main-resolution)
