### PR TITLE
docs: add gleam port to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Most stronger forms of the UUID / GUID algorithms require access to OS services 
 - [Cuid2 for Clojure](https://github.com/hden/cuid2) - [Haokang Den](https://github.com/hden)
 - [Cuid2 for ColdFusion](https://github.com/bennadel/CUID2-For-ColdFusion) - [Ben Nadel](https://github.com/bennadel)
 - [Cuid2 for Dart](https://github.com/obsidiaHQ/cuid2) - [George Mamar](https://github.com/obsidiaHQ)
+- [Cuid2 for Gleam](https://github.com/ilhamft/glecuid) - [Ilham Fathoni](https://github.com/ilhamft)
 - [Cuid2 for Java](https://github.com/thibaultmeyer/cuid-java) - [Thibault Meyer](https://github.com/thibaultmeyer)
 - [Cuid2 for .NET](https://github.com/visus-io/cuid.net) - [Visus](https://github.com/xaevik)
 - [Cuid2 for PHP](https://github.com/visus-io/php-cuid2) - [Visus](https://github.com/xaevik)


### PR DESCRIPTION
Hi, I've created a [Gleam port](https://github.com/ilhamft/glecuid) that works on Erlang and Javascript target. It includes collision/histogram test to validate the implementation.